### PR TITLE
Support win32 platform on Google search command

### DIFF
--- a/src/options/optSearch.js
+++ b/src/options/optSearch.js
@@ -5,10 +5,11 @@ function optSearch(query) {
   const queryGoogle = 'https://www.google.com/search?q=';
   const searchQuery = query.join('+');
   const searchAddress = queryGoogle + searchQuery;
+  const openCmd = process.platform === 'win32' ? 'start' : 'open';
 
   console.log(chalk.blue(`Searching for "${query.join(' ')}" on Google`));
   setTimeout(() => {
-    childProcess.exec(`open ${searchAddress}`, () => {
+    childProcess.exec(`${openCmd} ${searchAddress}`, () => {
     });
   }, 300);
 }

--- a/src/options/optSearch.test.js
+++ b/src/options/optSearch.test.js
@@ -30,9 +30,22 @@ describe('optSearch', () => {
 
   it('Should call child_process.exec with correct search URL', (done) => {
     const queryGoogle = 'https://www.google.com/search?q=';
+    // mock process for proper open command call
+    Object.defineProperty(process, 'platform', {value: 'unix'});
     optSearch(queryMock);
     setTimeout(() => {
       expect(childProcessStub).to.have.been.calledWith(`open ${queryGoogle}${queryMock.join('+')}`);
+      done();
+    }, 300);
+  });
+
+  it('Should call child_process.exec with correct search URL and win32 open command', (done) => {
+    const queryGoogle = 'https://www.google.com/search?q=';
+    // mock process for proper open command call
+    Object.defineProperty(process, 'platform', {value: 'win32'});
+    optSearch(queryMock);
+    setTimeout(() => {
+      expect(childProcessStub).to.have.been.calledWith(`start ${queryGoogle}${queryMock.join('+')}`);
       done();
     }, 300);
   });


### PR DESCRIPTION
```bash
$ open
bash: open: command not found
```
😢 